### PR TITLE
If provided, build docker image with environment variable

### DIFF
--- a/deploy-lightsail.sh
+++ b/deploy-lightsail.sh
@@ -27,8 +27,14 @@ CONFIG_CONTAINER=lightsail-container.json
 CONFIG_ENDPOINT=lightsail-endpoint.json
 
 # Build image
-echo "Building Docker image" 
-docker build -t $CONTAINER:latest .
+if [ ${NODE_ENV+x} ]; then
+  echo "Building Docker image with environment $NODE_ENV"
+  docker build -t $CONTAINER:latest . --build-arg NODE_ENV=$NODE_ENV
+else
+  echo "Building Docker image"
+  docker build -t $CONTAINER:latest .
+fi
+
 
 # Push image
 echo "Pushing Docker image" 


### PR DESCRIPTION
Vi har i vissa situationer velat ha ett development bygge (på dev-miljön) men då det är samma Dockerfil så ville vi ha ett sätt att sätta om NODE_ENV i byggskriptet.

Så med denna uppdatering så kan vi ha följande i vår Dockerfile
```
ARG NODE_ENV
ENV NODE_ENV=$NODE_ENV
ENV NODE_ENV=${NODE_ENV:-production}
```

istället för 
```
ENV NODE_ENV=production
```

Detta gör att, om $NODE_ENV är angiven som byggvariabel, sätt ENV till detta, annars blir det default produktion

Så allt vi behöver göra är att kalla på detta skript
```
run: curl -L https://raw.githubusercontent.com/lagenhetsbyte/build-scripts/master/deploy-lightsail.sh | bash -s REGION="eu-north-1" SERVICE="bytesansokan-hyresvard-dev" CONTAINER="bytesansokan-hyresvard-dev" PORT="3000" NODE_ENV="development"
```

(Alternativt staging/test eller vad nu vår miljö vill heta)


Om NODE_ENV inte finns med i detta skripts parametrar så ska skriptet fungera precis som innan, därav if-satsen.